### PR TITLE
Fix calculation in tickToWord function by applying right shift operat…

### DIFF
--- a/docs/sdk/v3/guides/advanced/02-pool-data.md
+++ b/docs/sdk/v3/guides/advanced/02-pool-data.md
@@ -99,7 +99,7 @@ Now that we have the address of a **USDC - ETH** Pool, we can construct an insta
 To construct the Contract we need to provide the address of the contract, its ABI and a provider connected to an [RPC endpoint](https://www.chainnodes.org/docs). We get access to the contract's ABI through the `@uniswap/v3-core` package, which holds the core smart contracts of the Uniswap V3 protocol:
 
 ```typescript
-import { ethers } from 'ethers
+import { ethers } from 'ethers'
 import IUniswapV3PoolABI from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 
 const provider = getProvider()
@@ -211,7 +211,7 @@ function tickToWord(tick: number): number {
   if (tick < 0 && tick % tickSpacing !== 0) {
     compressed -= 1
   }
-  return tick >> 8
+  return compressed >> 8
 }
 
 const minWord = tickToWord(-887272)


### PR DESCRIPTION
# Fix calculation in tickToWord function

## Description
This PR fixes an issue in the `tickToWord` function where the right shift operation was incorrectly applied to the original `tick` variable instead of the `compressed` variable. This caused incorrect word calculation, especially for negative tick values.

## Changes
- Modified the `tickToWord` function to apply the right shift operation (`>> 8`) to the `compressed` variable instead of directly to the `tick` variable
- Ensured proper handling of tick spacing and negative tick values

## Why This is Important
The current implementation ignores the special handling of negative ticks and tick spacing, which can lead to incorrect bitMap positions being calculated. This fix ensures that:
1. Tick spacing is properly considered
2. Negative ticks are handled correctly
3. The proper mapping between ticks and words is maintained